### PR TITLE
Rewords CLI Docs

### DIFF
--- a/src/docs.js
+++ b/src/docs.js
@@ -5,7 +5,7 @@ module.exports = [
       // { comment: 'Import an existing Electron application so you can use Electron Forge with it' },
       { line: 'electron-forge import [path]' },
     ],
-    description: ['Attempts to import the given module directory to the Electron Forge standard.  It does this by removing any existing Electron tooling and replacing it with electrom-compile, setting up git for you, adding a template forge config object to your package.json file and installing the correct NPM dependencies.', 'It will guide you through the import process with interactive prompts but be aware it modifies your files in place, so ensure you don\'t have uncommited changes before running this command or you might lose them'],
+    description: ['Attempts to import the given module directory to the Electron Forge standard. An interactive prompt will appear, removing any existing Electron tooling and replacing it with electron-compile, setting up git, adding a template forge config object to package.json, and installing the correct NPM dependencies.', 'This modifies any files in the directory - ensure that any changes are backed up.', 'By default, the path will be the current directory.'],
     arguments: [],
   },
   {
@@ -14,17 +14,17 @@ module.exports = [
       // { comment: 'Initialize a new Electron Forge application in the given directory' },
       { line: 'electron-forge init [path]' },
     ],
-    description: ['Initializes a new application from a basic temnplate that is compatabile with Electron Forge, out of the box we provide templates for React, Typescript, Angular and more. You can see all the available template on our "Templates" page.  If you do not provide a template we will simply give you a vanilla ES6/7 ready app template.', 'Templates will provide you with the minimum code required to get an app started along with all the forge config you will need to start building your app.', 'By default path will be the current directory'],
+    description: ['Initializes a new application from a basic template that is compatible with Electron Forge. Currently, there are templates for Vanilla ES6/ES7, React, Angular, Vue, and Jade - a list of the available templates is on the "Templates" page. If no template is provided, the command will default to the Vanilla ES6/ES7 template.', 'By default, the path will be the current directory.'],
     arguments: [
       {
         name: 'template',
         value: true,
-        description: 'The name of the template to use when initializing your app, the template is resolved from either a global module with the name "electron-forge-template-[name]" or from one of the internally provided template modules.  Not providing a template will default to the Vanilla ES6/7 template.',
+        description: 'The name of the template to use when initializing the app. The template is resolved from either a global module with the name "electron-forge-template-[name]", or from one of the internally provided template modules. Not providing a template will default to the Vanilla ES6/ES7 template.',
       },
       {
         name: 'lintstyle',
         value: true,
-        description: 'Some templates support this argument to change the linting tools that are provided for you, only the vanilla ES6/7 template supports this internally where you can choose between "airbnb" and "standard".',
+        description: 'Some templates support this argument to change the provided linting tools. The Vanilla ES6/ES7 template supports this, with two options: "airbnb" and "standard".',
       },
     ],
   },
@@ -33,11 +33,11 @@ module.exports = [
     usage: [
       { line: 'electron-forge install [owner]/[repo]' },
     ],
-    description: ['Installs an Electron application from the given GitHub repository in the form "owner/repo", for example "atom/atom".  It will attempt to install your platforms release and then launch it, the intention is to smoothly install Electron applications in a consistent way similar to brew.'],
+    description: ['Installs an Electron application from the given GitHub repository in the form  of "owner/repo" (for example "atom/atom"). It will install the current platform\'s release and then launch it, behaving similar to Homebrew.'],
     arguments: [
       {
         name: 'prerelease',
-        description: 'If you set the flag it will fetch the latest release include prereleases, these are ignored by default so if you want to install alpha or beta versions you need to enable this flag.',
+        description: 'By default, prereleases are ignored. However, setting the flag will fetch the latest release, prereleases inclusive.',
       },
     ],
   },
@@ -46,7 +46,7 @@ module.exports = [
     usage: [
       { line: 'electron-forge lint [path]' },
     ],
-    description: ['Runs the lint task of the application found at "path" and outputs the results if it fails, if it succeeds there will be no output.', 'By default path will be the current directory.'],
+    description: ['Runs the lint task of the application found at [path] and outputs the results if it fails; if it succeeds, there will be no output.', 'By default, the path will be the current directory.'],
     arguments: [],
   },
   {
@@ -54,21 +54,21 @@ module.exports = [
     usage: [
       { line: 'electron-forge make [path]' },
     ],
-    description: ['Makes platform specific distributables of your Electron application.  Currently you can only generate distributables for your current platform, this means for instance you can\'t generate Windows installers from a linux machine.', 'We reccomend running this command on CI (normally Travis CI and Appveyor) so that you can generate distributables for all 3 platforms.', 'By default path will be the current directory'],
+    description: ['Makes platform specific distributables of your Electron application. Currently, distributables can only be generated for the host platform (for example, a Windows installer cannot be generated from a Linux machine.', 'However, this can be circumvented by using a Continuous Integration service (such as Travis CI or Appveyor).', 'By default, the path will be the current directory'],
     arguments: [
       {
         name: 'arch',
         value: true,
-        description: 'The target architecture to make distributables for, can be a comma separated list of arches.  Defaults to your systems architecture',
+        description: 'The target architecture to make distributables for, entered as a comma-separated list. Defaults to the system architecture.',
       },
       {
         name: 'targets',
         value: true,
-        description: 'Override your forge config make targets by settings this argument to be a comma separated list of make targets, useful for running a single make for testing purposes.',
+        description: 'Overrides the directory\'s forge config make targets with a comma-separated list of make targets.',
       },
       {
         name: 'skip-package',
-        description: 'Setting this flag will assume the app has already been packaged, this can result in a faster "make" but also if used incorrectly can result in you making an out of date version of your application.',
+        description: 'If this flag is set, the app will be made without packaging.',
       },
     ],
   },
@@ -77,17 +77,17 @@ module.exports = [
     usage: [
       { line: 'electron-forge package [path]' },
     ],
-    description: ['Packages your Electron application into a platform specific folder.  This folder is not technically distributable so you normally need to run the "make" command and not this command.  If you need a faster build to debug a packaged verison of your app this is the command you should use', 'By default path will be the current directory'],
+    description: ['Packages the Electron application into a platform-specific folder. While this folder is not technically distributable, it is useful for local testing.', 'By default, the path will be the current directory'],
     arguments: [
       {
         name: 'arch',
         value: true,
-        description: 'The target architecture to package your applcation for, can be a comma separated list of arches.  Defaults to your system architecture.',
+        description: 'The target architecture to make distributables for, entered as a comma-separated list. Defaults to the system architecture.',
       },
       {
         name: 'platform',
         value: true,
-        description: 'The target platform to package your application for.  You can package your application for platforms other than your current system platform.  Defaults to your system platform.',
+        description: 'The target platform to package the application for. Unlike make, an application can be packaged for any platform from any platform. Defaults to the system platform.',
       },
     ],
   },
@@ -96,22 +96,22 @@ module.exports = [
     usage: [
       { line: 'electron-forge publish [path]' },
     ],
-    description: ['Publishes your Electron application to the given target service, it will upload the results of a "make" run directly to the publish target.  By default it publishes to GitHub.', 'You can pass through options to the "make" run by adding them as arguments to the publish call.', 'By default path will be the current directory'],
+    description: ['Publishes the Electron application, by running "make", to the given target service. By default it publishes to GitHub.', 'Add options to the "publish" command to have them run on the make call.', 'By default, the path will be the current directory'],
     arguments: [
       {
         name: 'auth-token',
         value: true,
-        description: 'The authorization token to pass through to the publisher you are using.  For the GitHub publisher for instance this will be a GitHub access token.',
+        description: 'The authorization token passed to the publisher. For GitHub, this would be a GitHub access token.',
       },
       {
         name: 'tag',
         value: true,
-        description: 'The version to tag this release as, defaults to your current package.json version',
+        description: 'The version number tagged to the release. Defaults to package.json.',
       },
       {
         name: 'target',
         value: true,
-        description: 'The publish target to send your make artifacts to, defaults to GitHub.  You can provide your own publish target in an "electron-forge-publish-[name]" package.',
+        description: 'The publish target service, which defaults to GitHub. You can provide your own publish target in an "electron-forge-publish-[name]" package.',
       },
     ],
   },
@@ -120,7 +120,7 @@ module.exports = [
     usage: [
       { line: 'electron-forge start [path]' },
     ],
-    description: ['Launches your Electron application after rebuilding native dependencies.  This will launch your app through "electron-prebuilt-compile" so that your code compiles on the fly (there is no precompile phase) this should make your development workflow nice and quick', 'Note, you can pass through any arguments you want to "start" and they will all be sent directly to your application', 'By default path will be the current directory'],
+    description: ['Launches your Electron application after rebuilding native dependencies. This launches the app through "electron-prebuilt-compile", which compiles the code on-the-fly instead of precompiling.', 'Any argument passed to "start" will be sent to the application.', 'By default, the path will be the current directory'],
     arguments: [],
   },
 ];


### PR DESCRIPTION
Hello,

I've enjoyed using Electron Forge so far, but I noticed the CLI documentation could be worded a bit better. I fixed a few typos, reworded some of the language to be more formal, and clarified some messy sentences. Let me know what you think!